### PR TITLE
Feat/add tooltip and module selection to the npc

### DIFF
--- a/css/hitos.css
+++ b/css/hitos.css
@@ -2415,3 +2415,38 @@ div[class*='grid-'] .column-nw {
   background-color: rgba(76, 175, 80, 0.15);
   mix-blend-mode: multiply;
 }
+
+.chat-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.chat-tooltip .chat-tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  bottom: 150%;
+  left: 50%;
+  margin-left: -60px;
+}
+
+.chat-tooltip .chat-tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+.chat-tooltip:hover .chat-tooltiptext {
+  visibility: visible;
+}

--- a/module/chat.js
+++ b/module/chat.js
@@ -43,13 +43,14 @@ function calculateDamage(weaponDamage, weaponKindBonus, diceValues){
     criticalMod = criticalMod > 1 ? criticalMod : 1;
     let damageTotal = (Number(damageBase) + Number(weaponKindBonus)) * Number(criticalMod);
     //let attack = Number(lookup["C"]) + actor.system.atributos.ref.value + actor.system.habilidades.combate.value + resistenciaMod + corduraMod
-    console.log(damageTotal)    
+    console.log(damageTotal)
     return damageTotal
 }
 
 async function onDramaRoll(event){
     console.log(event)
     let mods = Number(event.currentTarget.dataset.mods);
+    let modsTooltip = event.currentTarget.dataset.modstooltip.split(",");
     let dicesOld = event.currentTarget.dataset.roll.split(",");
     let actor = game.actors.get(event.currentTarget.dataset.actor);
     let weaponDamage = event.currentTarget.dataset.weapondamage;
@@ -94,6 +95,7 @@ async function onDramaRoll(event){
                             dices: dicesNew.sort((a, b) => a - b),
                             actor: actor.id,
                             mods: mods,
+                            modsTooltip: modsTooltip,
                             weaponDamage: weaponDamage,
                             weaponKindBonus: weaponKindBonus,
                             data: actor.system,
@@ -103,7 +105,7 @@ async function onDramaRoll(event){
                         ChatMessage.create({
                             content: html,
                             speaker: {alias: actor.name},
-                            type: CONST.CHAT_MESSAGE_TYPES.ROLL, 
+                            type: CONST.CHAT_MESSAGE_TYPES.ROLL,
                             rollMode: game.settings.get("core", "rollMode"),
                             roll: newRoll
                         });

--- a/module/dice.js
+++ b/module/dice.js
@@ -28,6 +28,11 @@ export async function _onInitRoll(actor) {
         dices: values[1],
         actor: actor._id,
         mods: Number(actor.system.iniciativa) + corduraMod + resistenciaMod,
+        modsTooltip: _formatModsTooltip([
+            {value: actor.system.iniciativa, key: "Iniciativa"},
+            {value: corduraMod, key: "EstabilidadMental"},
+            {value: resistenciaMod, key: "Resistencia"}
+        ]),
         data: actor.system,
         config: CONFIG.hitos,
     };
@@ -79,6 +84,12 @@ export async function _onAttackRoll(actor, weapon) {
         weaponKindBonus: weaponKindBonus,
         data: actor.system,
         mods: actor.system.atributos.ref.value + actor.system.habilidades.combate.value + resistenciaMod + corduraMod,
+        modsTooltip: _formatModsTooltip([
+            {value: actor.system.atributos.ref.value, key: "REF"},
+            {value: actor.system.habilidades.combate.value, key: "Combate"},
+            {value: corduraMod, key: "EstabilidadMental"},
+            {value: resistenciaMod, key: "Resistencia"}
+        ]),
         config: CONFIG.hitos
     };
     let html = await renderTemplate(template, dialogData);
@@ -103,6 +114,9 @@ export async function _onStatusRoll(actor, status) {
         dices: values[1],
         actor: actor._id,
         mods: Number(getProperty(actor.system, `${status}.value`)),
+        modsTooltip: _formatModsTooltip([
+            {value: Number(getProperty(actor.system, `${status}.value`)), key: statusLabel.replace("Hitos.","")}
+        ]),
         data: actor.system,
         config: CONFIG.hitos,
     };
@@ -152,6 +166,13 @@ export async function _onCheckRoll(actor, valor, habilidadNombre) {
                             dices: values[1],
                             actor: actor._id,
                             mods: Number(valor) + Number(html[0].querySelectorAll("option:checked")[0].value) + Number(html[0].querySelectorAll(".bonus")[0].value) + resistenciaMod + corduraMod,
+                            modsTooltip: _formatModsTooltip([
+                                {value: Number(valor), key: habilidadNombre.replace("Hitos.", "")},
+                                {value: Number(html[0].querySelectorAll("option:checked")[0].value), key: html[0].querySelectorAll("option:checked")[0].label.replace("Hitos.", "").substring(0, 3)},
+                                {value: Number(html[0].querySelectorAll(".bonus")[0].value), key: "Roll.Modificador"},
+                                {value: corduraMod, key: "EstabilidadMental"},
+                                {value: resistenciaMod, key: "Resistencia"}
+                            ]),
                             data: actor.system,
                             config: CONFIG.hitos,
                         };
@@ -177,4 +198,10 @@ function _rolld10(valor) {
     let d10s = d10Roll.result.split(" + ").sort((a, b) => a - b);
     let result = Number(d10s[1]) + Number(valor);
     return [d10Roll, d10s, result];
+}
+
+function _formatModsTooltip(data) {
+    return data.filter(({value}) => value !== 0).map(({value, key}) => {
+        return game.i18n.localize("Hitos." + key) + ": " + value;
+    });
 }

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -72,28 +72,29 @@
             </div>
             <div class="grid-2col habilidades-grid">
                 {{#each system.habilidades as |habilidad key| }}
-                <div class="row-nw stat-row align-center">
-                    <!-- <a class="spent-concept hide"><span class="fa fa-ban" data-habilidad={{habilidad}}></span></a> -->
-                    {{#iff key "contains" "adicional"}}
-                    <img class="habilidad-edit" src="./systems/hitos/assets/abilities/{{key}}.png" height="24px"
-                        width="24px" />
-                    <div class="label-body col col-xs-3 rollable-check" data-habilidad="{{key}}"
-                        data-edit="system.habilidades.{{key}}.label" contenteditable>
-                        {{{habilidad.label}}}
+                {{#ifGameModule habilidad}}
+                    <div class="row-nw stat-row align-center">
+                        <!-- <a class="spent-concept hide"><span class="fa fa-ban" data-habilidad={{habilidad}}></span></a> -->
+                        {{#iff key "contains" "adicional"}}
+                        <img class="habilidad-edit" src="./systems/hitos/assets/abilities/{{key}}.png" height="24px"
+                            width="24px" />
+                        <div class="label-body col col-xs-3 rollable-check" data-habilidad="{{key}}"
+                            data-edit="system.habilidades.{{key}}.label" contenteditable>
+                            {{{habilidad.label}}}
+                        </div>
+                        {{else}}
+                        <img src="./systems/hitos/assets/abilities/{{key}}.png" height="24px" width="24px" />
+                        <span class="label-body col col-xs-3 rollable-check"
+                            data-habilidad="{{key}}">{{localize habilidad.label}}</span>
+                        {{/iff}}
+                        <input class="input-body col-xs-1" name="system.habilidades.{{key}}.value" type="number"
+                            value="{{habilidad.value}}" />
+                        <div class="hito-disable concept-body col col-xs-8" data-edit="system.habilidades.{{key}}.concept"
+                            contenteditable>
+                            {{{habilidad.concept}}}
+                        </div>
                     </div>
-                    {{else}}
-                    <img src="./systems/hitos/assets/abilities/{{key}}.png" height="24px" width="24px" />
-                    <span class="label-body col col-xs-3 rollable-check"
-                        data-habilidad="{{key}}">{{localize habilidad.label}}</span>
-                    {{/iff}}
-                    <input class="input-body col-xs-1" name="system.habilidades.{{key}}.value" type="number"
-                        value="{{habilidad.value}}" />
-                    <div class="hito-disable concept-body col col-xs-8" data-edit="system.habilidades.{{key}}.concept"
-                        contenteditable>
-                        {{{habilidad.concept}}}
-                    </div>
-                </div>
-
+                {{/ifGameModule}}
                 {{/each}}
             </div>
         </div>
@@ -117,33 +118,107 @@
                                 <span class="section-title">{{localize "Hitos.Resistencia"}}</span>
                             </div>
                             <div class="grid-2col">
+                                <span class="label-body">{{localize "Hitos.Actual"}}</span>
                                 <input class="input-body" name="system.resistencia.value"
                                     value="{{system.resistencia.value}}" type="number" />
-                                <input class="input-body" name="system.resistencia.max" value="{{system.resistencia.max}}"
-                                    type="number" readonly />
+                                <span class="label-body">{{localize "Hitos.Consolidado"}}</span>
+                                <input class="input-body" name="system.resistencia.consolidated"
+                                    value="{{system.resistencia.consolidated}}" type="number" />
+                                <span class="label-body">{{localize "Hitos.Maximo"}}</span>
+                                <input class="input-body" name="system.resistencia.max"
+                                        value="{{system.resistencia.max}}" type="number" readonly />
+                            </div>
+                            <div class="grid-2col  margin-0">
+                                <img class="health-dec health-button" src="./systems/hitos/assets/health/minus.svg" height="25px" width="25px" />
+                                <img class="health-inc health-button" src="./systems/hitos/assets/health/add.svg" height="25px" width="25px" />
+                            </div>
+                            <div class="col-xs-12 health">
+                                <table>
+                                {{#times system.resistencia.max }}
+                                    {{#iff this "%" @root.system.aguante.value}}
+                                        {{#iff this "!=" 0}}
+                                            </tr>
+                                        {{/iff}}
+                                        <tr>
+                                    {{/iff}}
+                                    <td>
+                                        {{#iff this "<" @root.system.resistencia.consolidated}}
+                                            <div class="health-full-box"></div>
+                                        {{else}}
+                                            {{#iff this "<" @root.system.resistencia.value}}
+                                                <div class="health-crossed-box"></div>
+                                            {{else}}
+                                                <div class="health-empty-box"></div>
+                                            {{/iff}}
+                                        {{/iff}}
+                                    </td>
+
+                                    {{#iff this "==" (math @root.system.resistencia.max "-" 1)}}
+                                        </tr>
+                                    {{/iff}}
+                                {{/times}}
+                                </table>
                             </div>
                             <input class="col col-xs-12 input-body" name="system.resistencia.status"
                                 value="{{system.resistencia.status}}" type="text" readonly />
                         </div>
-                        <div class="column-nw">
-                            <div class="grid-2col">
-                                <span class="label-body rollable-status"
-                                    data-status="entereza">{{localize system.entereza.label}}</span>
-                                <input class="col input-body" name="system.entereza.value" value="{{system.entereza.value}}"
-                                    type="number" readonly />
+                        {{#ifMental}}
+                            <div class="column-nw">
+                                <div class="grid-2col">
+                                    <span class="label-body rollable-status"
+                                        data-status="entereza">{{localize system.entereza.label}}</span>
+                                    <input class="col input-body" name="system.entereza.value" value="{{system.entereza.value}}"
+                                        type="number" readonly />
+                                </div>
+                                <div class="row-nw col-xs-12">
+                                    <span class="section-title">{{localize "Hitos.EstabilidadMental"}}</span>
+                                </div>
+                                <div class="grid-2col">
+                                    <span class="label-body">{{localize "Hitos.Actual"}}</span>
+                                    <input class="input-body" name="system.estabilidadMental.value"
+                                        value="{{system.estabilidadMental.value}}" type="number" />
+                                    <span class="label-body">{{localize "Hitos.Consolidado"}}</span>
+                                    <input class="input-body" name="system.estabilidadMental.consolidated"
+                                        value="{{system.estabilidadMental.consolidated}}" type="number" />
+                                    <span class="label-body">{{localize "Hitos.Maximo"}}</span>
+                                    <input class="input-body" name="system.estabilidadMental.max"
+                                        value="{{system.estabilidadMental.max}}" type="number" readonly />
+                                </div>
+                                <div class="grid-2col margin-0">
+                                    <img class="mental-dec health-button" src="./systems/hitos/assets/health/minus.svg" height="25px" width="25px" />
+                                    <img class="mental-inc health-button" src="./systems/hitos/assets/health/add.svg" height="25px" width="25px" />
+                                </div>
+                                <div class="col-xs-12 health">
+                                    <table>
+                                    {{#times system.estabilidadMental.max }}
+                                        {{#iff this "%" @root.system.entereza.value}}
+                                            {{#iff this "!=" 0}}
+                                                </tr>
+                                            {{/iff}}
+                                            <tr>
+                                        {{/iff}}
+                                        <td>
+                                            {{#iff this "<" @root.system.estabilidadMental.consolidated}}
+                                                <div class="health-full-box"></div>
+                                            {{else}}
+                                                {{#iff this "<" @root.system.estabilidadMental.value}}
+                                                    <div class="health-crossed-box"></div>
+                                                {{else}}
+                                                    <div class="health-empty-box"></div>
+                                                {{/iff}}
+                                            {{/iff}}
+                                        </td>
+
+                                        {{#iff this "==" (math @root.system.estabilidadMental.max "-" 1)}}
+                                            </tr>
+                                        {{/iff}}
+                                    {{/times}}
+                                    </table>
+                                </div>
+                                <input class="col col-xs-12 input-body" name="system.estabilidadMental.status"
+                                    value="{{system.estabilidadMental.status}}" type="text" readonly />
                             </div>
-                            <div class="row-nw col-xs-12">
-                                <span class="section-title">{{localize "Hitos.EstabilidadMental"}}</span>
-                            </div>
-                            <div class="grid-2col">
-                                <input class="input-body" name="system.estabilidadMental.value"
-                                    value="{{system.estabilidadMental.value}}" type="number" />
-                                <input class="input-body" name="system.estabilidadMental.max"
-                                    value="{{system.estabilidadMental.max}}" type="number" readonly />
-                            </div>
-                            <input class="col col-xs-12 input-body" name="system.estabilidadMental.status"
-                                value="{{system.estabilidadMental.status}}" type="text" readonly />
-                        </div>
+                        {{/ifMental}}
                     </div>
                     <div>
                         <div class="row-nw col-xs-12">
@@ -154,18 +229,20 @@
                             {{{system.secuelas.value}}}
                         </div>
                     </div>
-                    <div class="stat-row">
-                        <div class="row-nw col-xs-12 align-center">
-                            <span class="section-title col col-xs-9">{{localize "Hitos.Degeneracion.Titulo"}}</span>
-                            <input class="input-body col col-xs-3" name="system.estabilidadMental.degeneracion.value"
-                                value="{{system.estabilidadMental.degeneracion.value}}" type="number" />
-                        </div>
+                    {{#ifMental}}
+                        <div class="stat-row">
+                            <div class="row-nw col-xs-12 align-center">
+                                <span class="section-title col col-xs-9">{{localize "Hitos.Degeneracion.Titulo"}}</span>
+                                <input class="input-body col col-xs-3" name="system.estabilidadMental.degeneracion.value"
+                                    value="{{system.estabilidadMental.degeneracion.value}}" type="number" />
+                            </div>
 
-                        <div class="input-header" data-edit="system.estabilidadMental.degeneracion.description"
-                            contenteditable>
-                            {{{system.estabilidadMental.degeneracion.description}}}
+                            <div class="input-header" data-edit="system.estabilidadMental.degeneracion.description"
+                                contenteditable>
+                                {{{system.estabilidadMental.degeneracion.description}}}
+                            </div>
                         </div>
-                    </div>
+                    {{/ifMental}}
                 </div>
                 <div class="combat-column">
                     <div class="row-nw section-header col-xs-12">
@@ -260,10 +337,10 @@
                 owner=owner editable=editable}}
                 <!-- <div class="hitos-body" name="system.extras" data-edit="system.extras"
                 contenteditable>
-                {{system.extras}} 
-                </div> 
+                {{system.extras}}
+                </div>
             -->
-                              
+
             </div>
             <ol class="gear-list item-list">
                 <div class="row-nw section-header col-xs-12">

--- a/templates/chat/chat-drama.html
+++ b/templates/chat/chat-drama.html
@@ -8,15 +8,22 @@
     </div>
     <div class="grid-2col font-s">
         <span><b>{{ localize "Hitos.Roll.Modificador" }}</b></span>
-        <span>{{mods}}</span>
+        <span class="chat-tooltip">
+            {{mods}}
+            <ul class="chat-tooltiptext">
+                {{#each modsTooltip as |modTooltip key| }}
+                    <li>{{modTooltip}}</li>
+                {{/each}}
+            </ul>
+        </span>
         {{#if damage}}
         <span><b>{{ localize "Hitos.Roll.Dano" }}</b></span>
         <span>{{damage}}</span>
         {{/if}}
         <span><b>{{ localize "Hitos.Roll.TiradaAnterior" }}</b></span>
         <span>{{dicesOld}}</span>
-        <span><b>{{ localize "Hitos.Roll.NuevaTirada" }}</b></span> 
+        <span><b>{{ localize "Hitos.Roll.NuevaTirada" }}</b></span>
         <span>{{dices}}</span>
     </div>
-    <a class="drama-roll font-l" data-actor="{{actor}}" data-roll="{{dices}}" data-mods="{{mods}}"  data-weaponDamage="{{weaponDamage}}" data-weaponKindBonus="{{weaponKindBonus}}"><i class="fas fa-dice"></i></a>
+    <a class="drama-roll font-l" data-actor="{{actor}}" data-roll="{{dices}}" data-mods="{{mods}}" data-modsTooltip="{{modsTooltip}}" data-weaponDamage="{{weaponDamage}}" data-weaponKindBonus="{{weaponKindBonus}}"><i class="fas fa-dice"></i></a>
 </div>

--- a/templates/chat/chat-roll.html
+++ b/templates/chat/chat-roll.html
@@ -5,18 +5,25 @@
     <div class="row-nw">
         <span class="col col-xs-6 padding-l-0"><b>{{ localize "Hitos.Roll.Resultado" }}</b></span>
         <div class="col col-xs-6 text-c"><span>{{total}}</span></div>
-    </div> 
+    </div>
     {{#if damage}}
     <div class="row-nw">
         <span class="col col-xs-6 padding-l-0"><b>{{ localize "Hitos.Roll.Dano" }}</b></span>
         <div class="col col-xs-6 text-c"><span>{{damage}}</span></div>
-    </div> 
-    {{/if}}   
+    </div>
+    {{/if}}
     <div class="grid-2col font-s">
         <span><b>{{ localize "Hitos.Roll.Tirada" }}</b></span>
         <span>{{dices}}</span>
         <span><b>{{ localize "Hitos.Roll.Modificador" }}</b></span>
-        <span>{{mods}}</span>
+        <span class="chat-tooltip">
+            {{mods}}
+            <ul class="chat-tooltiptext">
+                {{#each modsTooltip as |modTooltip key| }}
+                    <li>{{modTooltip}}</li>
+                {{/each}}
+            </ul>
+        </span>
     </div>
-    <a class="drama-roll font-l" data-actor="{{actor}}" data-roll="{{dices}}" data-mods="{{mods}}" data-weaponDamage="{{weaponDamage}}" data-weaponKindBonus="{{weaponKindBonus}}"><i class="fas fa-dice"></i></a>
+    <a class="drama-roll font-l" data-actor="{{actor}}" data-roll="{{dices}}" data-mods="{{mods}}" data-modsTooltip="{{modsTooltip}}" data-weaponDamage="{{weaponDamage}}" data-weaponKindBonus="{{weaponKindBonus}}"><i class="fas fa-dice"></i></a>
 </div>


### PR DESCRIPTION
Copied the logic of the character sheets to have the mental health hidden if defined by the system options. Also copied the health system (will try to create a simplified npc sheet in the future)

Added a tooltip on the roll chat to help players understand where the modification values are comming from, nothing necesary, but really useful for new players (based on some input with some new players)