### PR TITLE
Add id to system.json

### DIFF
--- a/system.json
+++ b/system.json
@@ -1,4 +1,5 @@
 {
+  "id": "hitos",
   "name": "hitos",
   "title": "Hitos",
   "description": "Implementación del sistema Hitos de Nosolorol para Foundry VTT.",


### PR DESCRIPTION
With version 13 of foundryVTT the system does not work anymore, it says it needs an ID on the manifest to be installed. I am not sure if more things are needed, but is a first step to fix it and keep on using it